### PR TITLE
Refs [TASK][34373] Show room in screen explore loadData

### DIFF
--- a/app/src/main/java/com/sun/americanroom/data/source/RoomDataSource.kt
+++ b/app/src/main/java/com/sun/americanroom/data/source/RoomDataSource.kt
@@ -2,6 +2,7 @@ package com.sun.americanroom.data.source
 
 import com.sun.americanroom.data.model.City
 import com.sun.americanroom.data.model.NewRoom
+import com.sun.americanroom.data.model.RoomExplore
 import com.sun.americanroom.data.model.TopRoom
 import com.sun.americanroom.data.source.remote.OnFetchDataJsonListener
 
@@ -27,5 +28,7 @@ interface RoomDataSource {
             state: String,
             city: String
         )
+
+        fun getRoomExplore(listener: OnFetchDataJsonListener<MutableList<RoomExplore>>)
     }
 }

--- a/app/src/main/java/com/sun/americanroom/data/source/remote/RoomRemoteDataSource.kt
+++ b/app/src/main/java/com/sun/americanroom/data/source/remote/RoomRemoteDataSource.kt
@@ -2,11 +2,13 @@ package com.sun.americanroom.data.source.remote
 
 import com.sun.americanroom.data.model.City
 import com.sun.americanroom.data.model.NewRoom
+import com.sun.americanroom.data.model.RoomExplore
 import com.sun.americanroom.data.model.TopRoom
 import com.sun.americanroom.data.source.RoomDataSource
 import com.sun.americanroom.data.source.remote.fetchjson.GetJsonFromUrl
 import com.sun.americanroom.utils.Constant
 import com.sun.americanroom.utils.KeyEntity
+import com.sun.americanroom.utils.StateCode
 
 class RoomRemoteDataSource private constructor() : RoomDataSource.Remote {
 
@@ -54,9 +56,21 @@ class RoomRemoteDataSource private constructor() : RoomDataSource.Remote {
             Constant.STATE +
             state +
             Constant.CITY +
-            city.replace(" ", Constant.CONSTRAINT_TEXT)+
+            city.replace(" ", Constant.CONSTRAINT_TEXT) +
             Constant.PAGE_DEFAULT
         GetJsonFromUrl(listener, KeyEntity.TOP_ROOM).execute(baseUrl)
+    }
+
+    override fun getRoomExplore(listener: OnFetchDataJsonListener<MutableList<RoomExplore>>) {
+        val baseUrl = Constant.BASE_URL +
+            Constant.TOP_REVIEW +
+            Constant.STATE +
+            StateCode.CALIFORNIA +
+            Constant.PAGE_DEFAULT +
+            Constant.ZIP_CODE +
+            Constant.API_KEY +
+            Constant.API_VALUE
+        GetJsonFromUrl(listener, KeyEntity.TOP_ROOM_SLIDER).execute(baseUrl)
     }
 
     private object Holder {

--- a/app/src/main/java/com/sun/americanroom/data/source/remote/fetchjson/ParseDataWithJson.kt
+++ b/app/src/main/java/com/sun/americanroom/data/source/remote/fetchjson/ParseDataWithJson.kt
@@ -1,6 +1,7 @@
 package com.sun.americanroom.data.source.remote.fetchjson
 
 import com.sun.americanroom.data.model.CityEntry
+import com.sun.americanroom.data.model.RoomExploreEntry
 import com.sun.americanroom.utils.Constant
 import com.sun.americanroom.utils.KeyEntity
 import com.sun.americanroom.utils.NewRoomEntry
@@ -56,6 +57,12 @@ class ParseDataWithJson {
                         keyEntity
                     )
                 }
+                KeyEntity.TOP_ROOM_SLIDER -> {
+                    parseJsonToList(
+                        jsonObjectContent?.getJSONArray(RoomExploreEntry.LIST),
+                        keyEntity
+                    )
+                }
                 else -> null
             }
         } catch (e: Exception) {
@@ -74,6 +81,9 @@ class ParseDataWithJson {
             }
             KeyEntity.NEW_ROOM -> {
                 parseJsonToModel.parseJsonToNewRoom(jsonObject)
+            }
+            KeyEntity.TOP_ROOM_SLIDER -> {
+                parseJsonToModel.parseJsonToRoomFromTop(jsonObject)
             }
             else -> null
         }
@@ -99,6 +109,12 @@ class ParseDataWithJson {
                 for (i in 0 until (jsonArray?.length() ?: 0)) {
                     val jsonObject = jsonArray?.getJSONObject(i)
                     if (data.size.equals(NUMBER_OF_ROOM)) return data
+                    data.add(parseJsonToObject(jsonObject, keyEntity))
+                }
+            }
+            KeyEntity.TOP_ROOM_SLIDER -> {
+                for (i in 0 until Constant.NUMBER_ROOM_SLIDER) {
+                    val jsonObject = jsonArray?.getJSONObject(i)
                     data.add(parseJsonToObject(jsonObject, keyEntity))
                 }
             }

--- a/app/src/main/java/com/sun/americanroom/data/source/remote/fetchjson/ParseJson.kt
+++ b/app/src/main/java/com/sun/americanroom/data/source/remote/fetchjson/ParseJson.kt
@@ -1,9 +1,6 @@
 package com.sun.americanroom.data.source.remote.fetchjson
 
-import com.sun.americanroom.data.model.City
-import com.sun.americanroom.data.model.CityEntry
-import com.sun.americanroom.data.model.NewRoom
-import com.sun.americanroom.data.model.TopRoom
+import com.sun.americanroom.data.model.*
 import com.sun.americanroom.utils.Constant
 import com.sun.americanroom.utils.NewRoomEntry
 import com.sun.americanroom.utils.TopRoomEntry
@@ -40,6 +37,20 @@ class ParseJson {
                 else getDouble(NewRoomEntry.STAR_RATING).toFloat(),
                 getString(NewRoomEntry.NAME),
                 getString(NewRoomEntry.STATE)
+            )
+        }
+
+    fun parseJsonToRoomFromTop(jsonObject: JSONObject?) =
+        jsonObject?.run {
+            RoomExplore(
+                getInt(RoomExploreEntry.ID),
+                getString(RoomExploreEntry.CITY),
+                getString(RoomExploreEntry.PICTURE_URL),
+                getInt(RoomExploreEntry.PRICE),
+                getString(RoomExploreEntry.NATIVE_CURRENCY),
+                getString(RoomExploreEntry.NAME),
+                getInt(RoomExploreEntry.REVIEWCOUNT),
+                getInt(RoomExploreEntry.STARRATING)
             )
         }
 }

--- a/app/src/main/java/com/sun/americanroom/data/source/repository/RoomRepository.kt
+++ b/app/src/main/java/com/sun/americanroom/data/source/repository/RoomRepository.kt
@@ -2,6 +2,7 @@ package com.sun.americanroom.data.source.repository
 
 import com.sun.americanroom.data.model.City
 import com.sun.americanroom.data.model.NewRoom
+import com.sun.americanroom.data.model.RoomExplore
 import com.sun.americanroom.data.model.TopRoom
 import com.sun.americanroom.data.source.RoomDataSource
 import com.sun.americanroom.data.source.local.RoomLocalDataSource
@@ -35,6 +36,10 @@ class RoomRepository private constructor(
         city: String
     ) {
         remote.getNewRoom(listener, state, city)
+    }
+
+    fun getRoomExplore(listener: OnFetchDataJsonListener<MutableList<RoomExplore>>) {
+        remote.getRoomExplore(listener)
     }
 
     companion object {

--- a/app/src/main/java/com/sun/americanroom/screen/explore/ExploreConstract.kt
+++ b/app/src/main/java/com/sun/americanroom/screen/explore/ExploreConstract.kt
@@ -1,15 +1,18 @@
 package com.sun.americanroom.screen.explore
 
 import com.sun.americanroom.data.model.City
+import com.sun.americanroom.data.model.RoomExplore
 import com.sun.americanroom.utils.BasePresenter
 
 interface ExploreContract {
     interface View {
         fun getCityOnSuccess(exploreCity: MutableList<City>)
         fun onError(exception: Exception?)
+        fun getRoomExploreSuccess(exploreRoom: MutableList<RoomExplore>)
     }
 
     interface Presenter : BasePresenter<View> {
         fun getCityExplore(state: String)
+        fun getRoomExplore()
     }
 }

--- a/app/src/main/java/com/sun/americanroom/screen/explore/ExplorePresenter.kt
+++ b/app/src/main/java/com/sun/americanroom/screen/explore/ExplorePresenter.kt
@@ -1,6 +1,7 @@
 package com.sun.americanroom.screen.explore
 
 import com.sun.americanroom.data.model.City
+import com.sun.americanroom.data.model.RoomExplore
 import com.sun.americanroom.data.source.remote.OnFetchDataJsonListener
 import com.sun.americanroom.data.source.repository.RoomRepository
 import com.sun.americanroom.utils.Constant
@@ -22,6 +23,18 @@ class ExplorePresenter(
                 view?.onError(exception)
             }
         }, state, Constant.NUMBER_CITY_DEFAULT)
+    }
+
+    override fun getRoomExplore() {
+        repository.getRoomExplore(object : OnFetchDataJsonListener<MutableList<RoomExplore>> {
+            override fun onSuccess(data: MutableList<RoomExplore>) {
+                view?.getRoomExploreSuccess(data)
+            }
+
+            override fun onError(exception: java.lang.Exception?) {
+                view?.onError(exception)
+            }
+        })
     }
 
     override fun onStart() {}

--- a/app/src/main/java/com/sun/americanroom/screen/explore/ExploreRoomFragment.kt
+++ b/app/src/main/java/com/sun/americanroom/screen/explore/ExploreRoomFragment.kt
@@ -61,6 +61,7 @@ class ExploreRoomFragment : Fragment(),
         explorePresenter.run {
             setView(this@ExploreRoomFragment)
             getCityExplore(StateCode.CALIFORNIA)
+            getRoomExplore()
         }
     }
 
@@ -71,6 +72,12 @@ class ExploreRoomFragment : Fragment(),
     }
 
     override fun onError(exception: Exception?) {}
+
+    override fun getRoomExploreSuccess(exploreRoom: MutableList<RoomExplore>) {
+        activity?.let {
+            adapterRoomExplore.updateDataRoomExplore(it, exploreRoom)
+        }
+    }
 
     companion object {
         fun newInstance() = ExploreRoomFragment()

--- a/app/src/main/java/com/sun/americanroom/utils/Constant.kt
+++ b/app/src/main/java/com/sun/americanroom/utils/Constant.kt
@@ -16,7 +16,9 @@ object Constant {
     const val NULL = "null"
     const val CITY = "&city="
     const val NEW_HOME = "airbnb-property/newly-listed"
-    const val NUMBER_CITY_DEFAULT=8
+    const val NUMBER_CITY_DEFAULT = 8
+    const val ZIP_CODE = "&zip_code=91342"
+    const val NUMBER_ROOM_SLIDER=3
 }
 
 object StateCode {
@@ -39,6 +41,7 @@ object KeyEntity {
     const val CITY = "city"
     const val TOP_ROOM = "top_room"
     const val NEW_ROOM = "new_room"
+    const val TOP_ROOM_SLIDER="top_room_slider"
 }
 
 object TopRoomEntry {


### PR DESCRIPTION
## Related Tickets
- [#Task 34373: Load Room In Top]
- https://edu-redmine.sun-asterisk.vn/issues/34373
## 
LoadData in Room in Slider
## Evidence (Screenshot or Video)
![5](https://user-images.githubusercontent.com/58133538/112786243-03450280-9080-11eb-87d5-0198acec565e.jpg)


## Review Checklist

Category | View Point | Description | Expected Reviewer Answer | Self review | Reviewer2 (name)
--- | --- | --- | --- | --- | ---
Conventions | Does the code follow Sun* coding style and coding conventions? | https://github.com/framgia/coding-standards/tree/master/eng/android | YES |<li>- [ ] yes</li>
Redmine | Does the ticket follow Sun* Redmine working process?  | https://github.com/framgia/Training-Guideline/blob/master/WorkingProcess/redmine/redmine.md| YES |<li>- [ ] yes</li>
Documentation | Is there any incomplete code? If so, should it be removed or flagged with a suitable marker like ‘TODO’? |  | YES |<li>- [ ] yes</li>